### PR TITLE
Replace fakemodel_* naming for indexes to tablename_*

### DIFF
--- a/peewee_moves.py
+++ b/peewee_moves.py
@@ -410,6 +410,7 @@ class Migrator:
         # set the database in the proxy
         meta = creator.model._meta
         meta.database.initialize(self.database)
+        meta.name = name
 
         yield creator
 


### PR DESCRIPTION
Hi. There is one problem. 
By default, all indexes created with "fakemodel" prefix.
So, if we have two tables with self-titled foreignkeys - we have a problem with their naming. 
This small PR solve it with replace fakemodel prefix to table prefix.
I hope it's useful for you too.