### PR TITLE
Fix building a list of upgrade operations for model classes by using case insensitive field type names

### DIFF
--- a/peewee_moves.py
+++ b/peewee_moves.py
@@ -111,7 +111,8 @@ def build_upgrade_from_model(model):
             }
             if field.null:
                 kwargs['null'] = True
-            coltype = 'int' if field.rel_field.field_type == 'primary_key' else field.rel_field.field_type
+            rel_field_type = field.rel_field.field_type.lower()
+            coltype = 'int' if rel_field_type == 'primary_key' else rel_field_type
             args.append(coltype)
 
         else:
@@ -354,7 +355,7 @@ class TableCreator:
                 indexes = ()
 
         # relate the field to the DummyRelated Model
-        rel_field_class = FIELD_TO_PEEWEE.get(coltype, peewee.IntegerField)
+        rel_field_class = FIELD_TO_PEEWEE.get(coltype.lower(), peewee.IntegerField)
         rel_field = rel_field_class()
         rel_field.bind(DummyRelated, rel_column)
         rel_field.model._meta.add_field(rel_column, rel_field)


### PR DESCRIPTION
Before the change, the library generated migration files using `field_type` from **peewee**, for example, `UUIDField` and `IntegerField` have uppercased `field_type` values:

```
class UUIDField(Field):
    field_type = 'UUID'
    ...
```

```
class IntegerField(Field):
    field_type = 'INT'
    ...
```

Using this field will generate the following migration file:

```
def upgrade(migrator):
    with migrator.create_table('performance_report_stat_unit') as table:
        table.foreign_key('UUID', 'session_uid', on_delete=None, on_update=None, references='performance_report_session.uid')
```

However, when applying migration, the type is searched using the values from `FIELD_TO_PEEWEE` that only contains lowercase values:

```
PEEWEE_TO_FIELD = {
    peewee.BareField: 'bare',
    peewee.BigIntegerField: 'biginteger',
    peewee.BlobField: 'blob',
    peewee.BooleanField: 'bool',
    peewee.CharField: 'char',
    peewee.DateField: 'date',
    peewee.DateTimeField: 'datetime',
    peewee.DecimalField: 'decimal',
    peewee.DoubleField: 'double',
    peewee.FixedCharField: 'fixed',
    peewee.FloatField: 'float',
    peewee.ForeignKeyField: 'foreign_key',
    peewee.IntegerField: 'int',
    peewee.AutoField: 'primary_key',
    peewee.SmallIntegerField: 'smallint',
    peewee.TextField: 'text',
    peewee.TimeField: 'time',
    peewee.TimestampField: 'int',
    peewee.UUIDField: 'uuid',
}

# Only available on peewee >= 3.3.4
if hasattr(peewee, 'BinaryUUIDField'):
    PEEWEE_TO_FIELD[peewee.BinaryUUIDField] = 'bin_uuid'

FIELD_TO_PEEWEE = {value: key for key, value in PEEWEE_TO_FIELD.items()}
```

Thus, we try to get a value using an incorrect key.
I suggest using casting to lowercase when searching and generating values.